### PR TITLE
Prefab editor error fix

### DIFF
--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -290,6 +290,12 @@ public class GridManager : MonoBehaviour
             if (pieceToSpawn != null)
             {
                 GridPiece newPiece = CustomMethods.Instantiate(pieceToSpawn, PieceParent);
+
+                if (newPiece == null)
+                {
+                    return;
+                }
+
                 newPiece.gameObject.name = pieceToSpawn.gameObject.name;
 
                 newPiece.CurrentCell = cells[i];

--- a/Assets/Scripts/SaveSystem/FileDataService.cs
+++ b/Assets/Scripts/SaveSystem/FileDataService.cs
@@ -27,11 +27,6 @@ namespace FinishOne.SaveSystem
             }
         }
 
-        private string GetFilePath(string fileName)
-        {
-            return Path.Combine(dataPath, string.Concat(fileName, ".", fileExtension));
-        }
-
         public void Save(GameData data, bool overwrite = true)
         {
             string filePath = GetFilePath(data.Name);
@@ -97,6 +92,11 @@ namespace FinishOne.SaveSystem
                     yield return Path.GetFileNameWithoutExtension(path);
                 }
             }
+        }
+
+        private string GetFilePath(string fileName)
+        {
+            return Path.Combine(dataPath, string.Concat(fileName, ".", fileExtension));
         }
     }
 }

--- a/Assets/Scripts/SaveSystem/SaveSystem.cs
+++ b/Assets/Scripts/SaveSystem/SaveSystem.cs
@@ -47,20 +47,6 @@ namespace FinishOne.SaveSystem
             gameData.LevelData = Bind<GridLevelManager, LevelData>(gameData.LevelData);
         }
 
-        private TData Bind<T, TData>(TData data) where T : MonoBehaviour, IBind<TData> where TData : ISaveable, new()
-        {
-            var entity = FindObjectsByType<T>(FindObjectsSortMode.None).FirstOrDefault();
-
-            if (entity != null)
-            {
-                data ??= new TData { Id = entity.Id };
-                entity.Bind(data);
-                return data;
-            }
-
-            return default;
-        }
-
         public void NewGame(bool allowSaving = true)
         {
             gameData = new GameData("Game");
@@ -91,5 +77,19 @@ namespace FinishOne.SaveSystem
 
         public void ReloadGame() => LoadGame(gameData.Name);
         public void DeleteGame(string name) => dataService.Delete(name);
+
+        private TData Bind<T, TData>(TData data) where T : MonoBehaviour, IBind<TData> where TData : ISaveable, new()
+        {
+            var entity = FindObjectsByType<T>(FindObjectsSortMode.None).FirstOrDefault();
+
+            if (entity != null)
+            {
+                data ??= new TData { Id = entity.Id };
+                entity.Bind(data);
+                return data;
+            }
+
+            return default;
+        }
     }
 }

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -5,7 +5,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "ee15819aef1091ee40cf7ac05a2a3bef79982111"
+      "hash": "a00d4c8951fe566616ecc2a82876fee94b574217"
     },
     "com.finishone.scene-management": {
       "version": "https://github.com/DevonOberdan/scene-management.git",


### PR DESCRIPTION
Error would appear every time a scene would open or the code would recompile, because editor spawning of pieces within a source prefab was trying to occur. This is now properly checked for.